### PR TITLE
docs: use tazama engineering email

### DIFF
--- a/Chart.yaml
+++ b/Chart.yaml
@@ -24,9 +24,9 @@ keywords:
   - vault
 home: https://github.com/frmscoe/EKS-helm
 maintainers:
-  - name: kyle
-    email: kyle.vorster@sybrin.com
-    url: https://github.com/vorsterk
+  - name: Tazama
+    email: engineering@tazama.com
+    url: https://github.com/tazama-lf
 dependencies:
   - name: apm
     version: 8.5.1


### PR DESCRIPTION
# SPDX-License-Identifier: Apache-2.0

## What did we change?
Use tazama engineering email instead of individual names.

## How was it tested?
- [ ] Locally
- [ ] Development Environment
- [x] Not needed, changes very basic
- [ ] Husky successfully run
- [ ] Unit tests passing and Documentation done
